### PR TITLE
turn off auto release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,15 +11,16 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      # Get PR from merged commit to master
+      # Get PR from merged commit to main
       - uses: actions-ecosystem/action-get-merged-pull-request@v1
         id: get-merged-pull-request
         with:
           github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         with:
-          publish: ${{ !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') }}
+          publish: false
           prerelease: false
           config-name: auto-release.yml
         env:


### PR DESCRIPTION
## what
* Turn off auto-release

## why
- We have renovate bot configured to update the yarn dependencies and we don't want each PR we merge to automatically create a new release. Instead, the changes will be accumulated in a draft release and we will release that manually.
